### PR TITLE
Fix bad cache load

### DIFF
--- a/c2eaPfinder.py
+++ b/c2eaPfinder.py
@@ -40,6 +40,8 @@ initialHash = None
 def loadCache():
     global cachesLoaded
     global initialHash
+    global caches
+    
     if not cachesLoaded:
         import os, pickle
         if os.path.exists("./.cache"):
@@ -61,6 +63,8 @@ def writeCache():
             pickle.dump(caches, f, pickle.HIGHEST_PROTOCOL)
 
 def deleteCache():
+    global caches
+    
     for name in caches:
         caches[name] = {}
     writeCache()


### PR DESCRIPTION
`loadCache` would load the cache dump into a local instead of the global `caches` variable; And would raise an exception if `.cache` did not exist (since the local wouldn't exist either).