### PR TITLE
Add new commandline options, including the ability to process one CSV at a time

### DIFF
--- a/c2ea.py
+++ b/c2ea.py
@@ -171,20 +171,24 @@ def main():
         
         rom = args.rom
         
-        if args.folder != None:
-            folder = args.folder
-            
-        installer = args.installer if args.installer != None else (folder + '/Table Installer.event')
-        
         if args.csv != None:
+            if (args.folder != None) or (args.installer != None):
+                sys.exit("ERROR: -folder or -installer argument specified with -csv, aborting.")
+            
             doSingleFile = True
             
             csvFile = args.csv
             nmmFile = args.nmm if args.nmm != None else csvFile.replace(".csv", ".nmm")
             outFile = args.out if args.out != None else csvFile.replace(".csv", ".event")
         
-        elif (args.nmm != None) or (args.out != None):
-            sys.exit("ERROR: -nmm or -out argument specified without -csv, aborting.")
+        else:
+            if (args.nmm != None) or (args.out != None):
+                sys.exit("ERROR: -nmm or -out argument specified without -csv, aborting.")
+            
+            if args.folder != None:
+                folder = args.folder
+            
+            installer = args.installer if args.installer != None else (folder + '/Table Installer.event')
 
     if doSingleFile:
         if not os.path.exists(csvFile):

--- a/c2ea.py
+++ b/c2ea.py
@@ -27,7 +27,7 @@ def addToInstaller(csvList,installername):
         nmpath = csv.replace(".csv",".nmm")
         nmm = nightmare.NightmareTable(nmpath)
         filename = csv.replace(".csv",".event") #I don't wanna use .txt because it conflicts, but this is supposed to be a text file!
-        filename = filename.replace(os.getcwd()+'\\','')
+        filename = os.path.relpath(filename, os.path.dirname(installername)) # filename.replace(os.getcwd()+'\\','')
         with open(installername,'a') as myfile:
             #myfile.write("ORG " + hex(nmm.offset) + '\n') Don't put the offset here, have it in the dmp.
             myfile.write('#include "' + filename + '"\n\n')

--- a/c2ea.py
+++ b/c2ea.py
@@ -36,7 +36,7 @@ def process(inputCSV, inputNMM, filename, rom):
     """Takes a csv and spits out an EA macro file (.event, but actually text). Requires a nmm with the same name in the same folder.""" #is it possible to tell if it's inline?
     global TABLE_INLINED
 
-    macroName = "_C2EA_{}".format(os.path.split(os.path.splitext(inputCSV)[0])[1].replace(os.path.sep, "_")).replace(' ', '_')
+    macroName = "_C2EA_{}".format(os.path.split(os.path.splitext(inputCSV)[0])[1].replace(' ', '_'))
 
     nmm = nightmare.NightmareTable(inputNMM)
     rompath = rom

--- a/c2ea.py
+++ b/c2ea.py
@@ -151,21 +151,21 @@ def main():
     if len(sys.argv) > 1:
         import argparse
         
-        parser = argparse.ArgumentParser()
+        parser = argparse.ArgumentParser(description = 'Convert CSV file(s) to EA events using NMM file(s) are reference. Defaults to looking for CSVs in the current directory. You can specify a directory to look in using -folder, or you can switch to processing singles CSVs using -csv.')
         
         # Common arguments
-        parser.add_argument('rom', nargs='?')
+        parser.add_argument('rom', nargs='?', help = 'reference ROM (for pointer searching)')
         # parser.add_argument('-nocache') # sounds like no$ xd
         # parser.add_argument('-clearcache')
         
         # Arguments for single CSV processing
-        parser.add_argument('-nmm')
-        parser.add_argument('-csv')
-        parser.add_argument('-out')
+        parser.add_argument('-csv', help = 'CSV for single csv processing')
+        parser.add_argument('-nmm', help = '(use with -csv) reference NMM (default: [CSVFile]:.csv=.nmm)')
+        parser.add_argument('-out', help = '(use with -csv) output event (default: [CSVFile]:.csv=.event)')
 
         # Arguments for folder processing
-        parser.add_argument('-folder')
-        parser.add_argument('-installer')
+        parser.add_argument('-folder', help = 'folder to look for csvs in')
+        parser.add_argument('-installer', help = 'output installer event (default: [Folder]/Table Installer.event)')
         
         args = parser.parse_args()
         

--- a/c2ea.py
+++ b/c2ea.py
@@ -187,6 +187,12 @@ def main():
             sys.exit("ERROR: -nmm or -out argument specified without -csv, aborting.")
 
     if doSingleFile:
+        if not os.path.exists(csvFile):
+            sys.exit("ERROR: CSV File `{}` doesn't exist!".format(csvFile))
+        
+        if not os.path.exists(nmmFile):
+            sys.exit("ERROR: NMM File `{}` doesn't exist!".format(nmmFile))
+        
         process(csvFile, nmmFile, outFile, rom)
     
     else: # not doSingleFile

--- a/c2ea.py
+++ b/c2ea.py
@@ -192,15 +192,14 @@ def main():
     else: # not doSingleFile
         csvList = glob.glob(folder + '/**/*.csv', recursive = True)
         
-        for index, csvfile in enumerate(csvList):
+        for filename in csvList:
             rom = process(
-                csvfile,
-                csvfile.replace(".csv",".nmm"),
-                csvfile.replace(".csv",".event"),
+                filename,
+                filename.replace(".csv",".nmm"),
+                filename.replace(".csv",".event"),
                 rom
             )
         
-        installer = "Table Installer.event"
         addToInstaller(csvList, installer)
     
     if TABLE_INLINED:


### PR DESCRIPTION
USAGE:
```
c2ea [-folder <folder>] [-installer <installer>] [ROM]
```
or
```
c2ea -csv <file> [-nmm <file>] [-out <file>] [ROM]
```

Also changed the way the row EA macro name is generated (based on csv filename, because we need to have a way to differentiate the macro between different table events).