### PR TITLE
Add makefile for generating distribution/release folder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+.PHONY: dist clean
+
+ifndef DIST_DIR
+ # Set default release directory
+ DIST_DIR := ReleaseDist
+endif
+
+dist: c2ea.py n2c.py icon.ico
+	mkdir -p "$(DIST_DIR)"
+	pyinstaller -F --distpath "$(DIST_DIR)" --icon=icon.ico c2ea.py
+	pyinstaller -F --distpath "$(DIST_DIR)" --icon=icon.ico n2c.py
+	cp -f "Readme.md" "$(DIST_DIR)/Readme.md"
+	cp -f "Table Definitions.txt" "$(DIST_DIR)/Table Definitions.txt"
+
+clean:
+	rm -rf $(DIST_DIR)


### PR DESCRIPTION
(requires `pyinstaller`, which still requires python < 3.7 as I write these lines).

Example usages:

    make
    make DIST_DIR=OtherReleaseDist
    make clean DIST_DIR=OtherReleaseDist

Default `DIST_DIR` is `ReleaseDist`.

The output folder will contain `c2ea.exe`, `n2c.exe`, `Table Definitions.txt` and `README.md`. After generating the folder, you just need to package it up and distribute.