### PR TITLE
Add definition from entry list generation to N2C

### DIFF
--- a/n2c.py
+++ b/n2c.py
@@ -1,65 +1,95 @@
 import nightmare, csv, sys, glob, os
-import tkinter as tk
-from tkinter import filedialog
 
-def show_exception_and_exit(exc_type, exc_value, tb):
+def showExceptionAndExit(exc_type, exc_value, tb):
     import traceback
     traceback.print_exception(exc_type, exc_value, tb)
     input("Press Enter key to exit.")
     sys.exit(-1)
 
-def process(nmm,rom,filename):
+def process(nmm, rom, outFile):
+    # First cell is offset of table in ROM
     headers = [hex(nmm.offset)]
+    
+    # Generate header row (contains field descriptions)
     for col in nmm.columns:
         headers.append(col.description)
+    
     table = [headers]
 
     for row in range(nmm.rowNum):
+        # rowOffset is the offset in ROM of the row data
         rowOffset = nmm.offset + row*nmm.rowLength
+        
+        # First cell is row/entry name
         try:
             thisRow = [nmm.entryNames[row]]
+        
         except IndexError:
             thisRow = [hex(row)]
-        for col in range(nmm.colNum):
-            entry = nmm.columns[col]
+        
+        for entry in nmm.columns:
+            # currentOffset is offset in ROM of current field data
             currentOffset = rowOffset + entry.offset
-            dt = int.from_bytes(rom[currentOffset:currentOffset+entry.length], 'little', signed=entry.signed)
-            if (entry.base==16):
+            
+            # get int from data
+            dt = int.from_bytes(rom[currentOffset:currentOffset+entry.length], 'little', signed = entry.signed)
+            
+            if (entry.base == 16):
                 dt = hex(dt)
+            
             thisRow.append(dt)
+        
         table.append(thisRow)
-    # rom.close()
     
-    with open(filename, 'w') as myfile:
-        wr = csv.writer(myfile, quoting=csv.QUOTE_ALL, lineterminator='\n')
+    # Write table as csv
+    with open(outFile, 'w') as myfile:
+        wr = csv.writer(myfile, quoting = csv.QUOTE_ALL, lineterminator = '\n')
         wr.writerows(table)
-    print("Wrote to " + filename)
+
+    print("Wrote to " + outFile)
 
 def main():
-    sys.excepthook = show_exception_and_exit
+    sys.excepthook = showExceptionAndExit
+
     try:
-        inputROM = sys.argv[1]
+        romFile = sys.argv[1]
+
     except IndexError:
+        import tkinter as tk
+        from tkinter import filedialog
+
         root = tk.Tk()
         root.withdraw()
-        inputROM = filedialog.askopenfilename(filetypes=[("GBA files",".gba"),("All files",".*")],initialdir=os.getcwd(),title="Select ROM to rip data from")
-    (dirname,filename) = os.path.split(inputROM)
-    # if (dirname):
-    #     moduleList = glob.glob(dirname + '/**/*.nmm',recursive=True) #a list of all nightmare modules in the directory
-    # else:
-    #     moduleList = glob.glob('**/*.nmm',recursive=True)
-    moduleList = glob.glob('**/*.nmm',recursive=True)
-    for inputNMM in moduleList:
-        outputname = inputNMM.replace(".nmm",".csv") #let's just keep the same file name for now
-        # print("Module:\t" + inputNMM)
-        # print("Output:\t" + outputname)
+
+        romFile = filedialog.askopenfilename(
+            title = "Select ROM to rip data from",
+            initialdir = os.getcwd(),
+            filetypes = [
+                ("GBA files", ".gba"),
+                ("All files", ".*")
+            ]
+        )
+
+    (dirname, filename) = os.path.split(romFile)
+    
+    # generating module list
+    moduleList = glob.glob('**/*.nmm', recursive=True)
+
+    # read ROM bytes
+    with open(romFile, 'rb') as f:
+        romBytes = bytes(f.read())
+    
+    for nmmFile in moduleList:
+        csvFile = nmmFile.replace(".nmm", ".csv") #let's just keep the same file name for now
+
         try:
-            nmm = nightmare.NightmareTable(inputNMM)
-            with open(inputROM, 'rb') as rom_file:
-                rom = bytes(rom_file.read())
-            process(nmm, rom, outputname)
+            nmm = nightmare.NightmareTable(nmmFile)
+            process(nmm, romBytes, csvFile)
+        
         except AssertionError as e:
-            print("Error in " + inputNMM+":\n" + str(e))
+            # NMM is malformed
+            print("Error in " + nmmFile + ":\n" + str(e))
+
     input("Press Enter to continue.")
 
 if __name__ == '__main__':

--- a/n2c.py
+++ b/n2c.py
@@ -9,58 +9,58 @@ def show_exception_and_exit(exc_type, exc_value, tb):
     sys.exit(-1)
 
 def process(nmm,rom,filename):
-  headers = [hex(nmm.offset)]
-  for col in nmm.columns:
-    headers.append(col.description)
-  table = [headers]
+    headers = [hex(nmm.offset)]
+    for col in nmm.columns:
+        headers.append(col.description)
+    table = [headers]
 
-  for row in range(nmm.rowNum):
-    rowOffset = nmm.offset + row*nmm.rowLength
-    try:
-      thisRow = [nmm.entryNames[row]]
-    except IndexError:
-      thisRow = [hex(row)]
-    for col in range(nmm.colNum):
-      entry = nmm.columns[col]
-      currentOffset = rowOffset + entry.offset
-      dt = int.from_bytes(rom[currentOffset:currentOffset+entry.length], 'little', signed=entry.signed)
-      if (entry.base==16):
-        dt = hex(dt)
-      thisRow.append(dt)
-    table.append(thisRow)
-  # rom.close()
-  
-  with open(filename, 'w') as myfile:
-    wr = csv.writer(myfile, quoting=csv.QUOTE_ALL, lineterminator='\n')
-    wr.writerows(table)
-  print("Wrote to " + filename)
+    for row in range(nmm.rowNum):
+        rowOffset = nmm.offset + row*nmm.rowLength
+        try:
+            thisRow = [nmm.entryNames[row]]
+        except IndexError:
+            thisRow = [hex(row)]
+        for col in range(nmm.colNum):
+            entry = nmm.columns[col]
+            currentOffset = rowOffset + entry.offset
+            dt = int.from_bytes(rom[currentOffset:currentOffset+entry.length], 'little', signed=entry.signed)
+            if (entry.base==16):
+                dt = hex(dt)
+            thisRow.append(dt)
+        table.append(thisRow)
+    # rom.close()
+    
+    with open(filename, 'w') as myfile:
+        wr = csv.writer(myfile, quoting=csv.QUOTE_ALL, lineterminator='\n')
+        wr.writerows(table)
+    print("Wrote to " + filename)
 
 def main():
-  sys.excepthook = show_exception_and_exit
-  try:
-    inputROM = sys.argv[1]
-  except IndexError:
-    root = tk.Tk()
-    root.withdraw()
-    inputROM = filedialog.askopenfilename(filetypes=[("GBA files",".gba"),("All files",".*")],initialdir=os.getcwd(),title="Select ROM to rip data from")
-  (dirname,filename) = os.path.split(inputROM)
-  # if (dirname):
-  #   moduleList = glob.glob(dirname + '/**/*.nmm',recursive=True) #a list of all nightmare modules in the directory
-  # else:
-  #   moduleList = glob.glob('**/*.nmm',recursive=True)
-  moduleList = glob.glob('**/*.nmm',recursive=True)
-  for inputNMM in moduleList:
-    outputname = inputNMM.replace(".nmm",".csv") #let's just keep the same file name for now
-    # print("Module:\t" + inputNMM)
-    # print("Output:\t" + outputname)
+    sys.excepthook = show_exception_and_exit
     try:
-      nmm = nightmare.NightmareTable(inputNMM)
-      with open(inputROM, 'rb') as rom_file:
-        rom = bytes(rom_file.read())
-      process(nmm, rom, outputname)
-    except AssertionError as e:
-      print("Error in " + inputNMM+":\n" + str(e))
-  input("Press Enter to continue.")
+        inputROM = sys.argv[1]
+    except IndexError:
+        root = tk.Tk()
+        root.withdraw()
+        inputROM = filedialog.askopenfilename(filetypes=[("GBA files",".gba"),("All files",".*")],initialdir=os.getcwd(),title="Select ROM to rip data from")
+    (dirname,filename) = os.path.split(inputROM)
+    # if (dirname):
+    #     moduleList = glob.glob(dirname + '/**/*.nmm',recursive=True) #a list of all nightmare modules in the directory
+    # else:
+    #     moduleList = glob.glob('**/*.nmm',recursive=True)
+    moduleList = glob.glob('**/*.nmm',recursive=True)
+    for inputNMM in moduleList:
+        outputname = inputNMM.replace(".nmm",".csv") #let's just keep the same file name for now
+        # print("Module:\t" + inputNMM)
+        # print("Output:\t" + outputname)
+        try:
+            nmm = nightmare.NightmareTable(inputNMM)
+            with open(inputROM, 'rb') as rom_file:
+                rom = bytes(rom_file.read())
+            process(nmm, rom, outputname)
+        except AssertionError as e:
+            print("Error in " + inputNMM+":\n" + str(e))
+    input("Press Enter to continue.")
 
 if __name__ == '__main__':
-  main()
+    main()

--- a/n2c.py
+++ b/n2c.py
@@ -14,7 +14,7 @@ def genIdentifierEntries(names):
     for name in names:
         yield re.sub(r'\W+', '', name)
 
-def process(nmm, rom, outFile):
+def genTableRows(nmm, rom):
     # First cell is offset of table in ROM
     headers = [hex(nmm.offset)]
     
@@ -22,7 +22,7 @@ def process(nmm, rom, outFile):
     for col in nmm.columns:
         headers.append(col.description)
     
-    table = [headers]
+    yield headers
 
     for row in range(nmm.rowNum):
         # rowOffset is the offset in ROM of the row data
@@ -50,12 +50,13 @@ def process(nmm, rom, outFile):
             
             thisRow.append(dt)
         
-        table.append(thisRow)
-    
+        yield thisRow
+
+def process(nmm, rom, outFile):
     # Write table as csv
-    with open(outFile, 'w') as myfile:
-        wr = csv.writer(myfile, quoting = csv.QUOTE_ALL, lineterminator = '\n')
-        wr.writerows(table)
+    with open(outFile, 'w') as f:
+        wr = csv.writer(f, quoting = csv.QUOTE_ALL, lineterminator = '\n')
+        wr.writerows(genTableRows(nmm, rom))
 
     print("Wrote to " + outFile)
 

--- a/n2c.py
+++ b/n2c.py
@@ -1,10 +1,18 @@
-import nightmare, csv, sys, glob, os
+import nightmare, csv, sys, glob, os, re
 
 def showExceptionAndExit(exc_type, exc_value, tb):
     import traceback
     traceback.print_exception(exc_type, exc_value, tb)
     input("Press Enter key to exit.")
     sys.exit(-1)
+
+def genIdentifierEntries(names):
+    """
+    Filters entry list of an nmm to contain names suitable for EA/C identifiers.
+    """
+    
+    for name in names:
+        yield re.sub(r'\W+', '', name)
 
 def process(nmm, rom, outFile):
     # First cell is offset of table in ROM
@@ -23,6 +31,9 @@ def process(nmm, rom, outFile):
         # First cell is row/entry name
         try:
             thisRow = [nmm.entryNames[row]]
+            
+            if thisRow[0] == "":
+                thisRow[0] = hex(row)
         
         except IndexError:
             thisRow = [hex(row)]
@@ -84,6 +95,9 @@ def main():
 
         try:
             nmm = nightmare.NightmareTable(nmmFile)
+            
+            nmm.entryNames = [x for x in genIdentifierEntries(nmm.entryNames)]
+            
             process(nmm, romBytes, csvFile)
         
         except AssertionError as e:


### PR DESCRIPTION
This should address about half of #7, the other half would be to generate definitions from various field dropdown value lists things (this would require adding features to `nightmare.py`, I'm waiting for this to be reviewed and such before starting work on that).

In addition to that, I also went and basically restructured `n2c` quite a bit.

To enable definition generation, use commandline options:

```
usage: n2c.py [-h] [-f FOLDER] [-e] [-d] [-a] [rom]

Convert NMM files to CSV files using a ROM as reference.

positional arguments:
  rom                   reference ROM.

optional arguments:
  -h, --help            show this help message and exit
  -f FOLDER, --folder FOLDER
                        folder to search for NMMs in.
  -e, --enums           translates entry lists to C enums.
  -d, --defines         translates entry lists to defines.
  -a, --assigns         translates entry lists to `name = id` expressions.
```

As you can see, there's three different ways of generating the list:

- Enums: will generate a file containing `enum { Name = Index, ... };`, suitable for usage in C.
- Defines: will generate a file containing `#define Name Index...`, suitable for usage in C, EA or anything cpp-preprocessed.
- Assigns: will generate a file containing `Name = Index...`, suitable for usage in EA (not ColorzCore yet) and ASM.

The names are generated from the entry names, with all non `[A-Za-z0-9_]` characters removed (Ex: `Grado Soldier` -> `GradoSoldier`; `L'Arachel` -> `LArachel`). If entry list generation is enabled, the names in the first column of the generated CSV will also have the filtered names (this may end up becoming useful when we end up implementing stuff like `ROWS` (see #6 )).

The generated files will have the same filename as the `nmm`s, with the extension changed to `def` (for example, `FE8 Character Editor.nmm` -> `FE8 Character Editor.def`).